### PR TITLE
Add prefix DOM test

### DIFF
--- a/src/components/Input/Input.test.js
+++ b/src/components/Input/Input.test.js
@@ -38,6 +38,12 @@ describe("Input", () => {
     expect(placeholder).toBeInTheDocument();
   });
 
+  it("should render prefix", () => {
+    const { prefix } = setup();
+
+    expect(prefix).toBeInTheDocument();
+  });
+
   it("should onChange event work properly", async () => {
     const user = userEvent.setup();
     const { input } = setup();


### PR DESCRIPTION
## Summary
- add test verifying the Input component renders prefix element

## Testing
- `npm test -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a8ac2e308332adaeac861cf0763e